### PR TITLE
Strip DEFINER from CREATE TRIGGER statements

### DIFF
--- a/src/Service/Database/Shell.php
+++ b/src/Service/Database/Shell.php
@@ -13,6 +13,7 @@ use Meanbee\Magedbm2\Shell\Command\Gunzip;
 use Meanbee\Magedbm2\Shell\Command\Gzip;
 use Meanbee\Magedbm2\Shell\Command\Mysql;
 use Meanbee\Magedbm2\Shell\Command\Mysqldump;
+use Meanbee\Magedbm2\Shell\Command\Sed;
 use Meanbee\Magedbm2\Shell\Pipe;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -158,6 +159,9 @@ class Shell implements DatabaseInterface
                     ->argument('-')
                     ->argument($structureOutputFile)
                     ->argument($dataOutputFile)
+            )->command(
+                (new Sed())
+                    ->argument("-e 's/DEFINER[ ]*=[ ]*[^*]*\*/\*/'")
             )->command(
                 (new Gzip())
                     ->argument('-9')

--- a/src/Shell/Command/Sed.php
+++ b/src/Shell/Command/Sed.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Meanbee\Magedbm2\Shell\Command;
+
+class Sed extends Base
+{
+    protected function name(): string
+    {
+        return 'sed';
+    }
+}


### PR DESCRIPTION
Keeping the definer statements in there makes it impossible to import a database backup unless you have the SUPER privilege.

Closes #13.